### PR TITLE
refactor: improve configuration and logging

### DIFF
--- a/configure.ts
+++ b/configure.ts
@@ -70,5 +70,6 @@ export async function configure(command: ConfigureCommand) {
    */
   await codemods.updateRcFile((rcFile) => {
     rcFile.addProvider(`${command.name}/kafka_provider`)
+    rcFile.addPreloadFile(`#start/kafka`)
   })
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "exports": {
     ".": "./build/index.js",
+    "./env": "./build/src/env/index.js",
     "./types": "./build/src/types.js",
     "./kafka_provider": "./build/providers/kafka_provider.js",
     "./services/kafka": "./build/services/kafka.js"
@@ -91,6 +92,7 @@
   "tsup": {
     "entry": [
       "./index.ts",
+      "./src/env/index.ts",
       "./src/types.ts",
       "./services/kafka.ts",
       "./providers/kafka_provider.ts",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@adonisjs/assembler": "^7.0.0",
     "@adonisjs/core": "^6.2.0",
     "@adonisjs/eslint-config": "^1.2.1",
+    "@adonisjs/logger": "^6.0.3",
     "@adonisjs/prettier-config": "^1.2.1",
     "@adonisjs/tsconfig": "^1.2.1",
     "@japa/assert": "^2.1.0",
@@ -61,7 +62,8 @@
     "kafkajs": "^2.2.4"
   },
   "peerDependencies": {
-    "@adonisjs/core": "^6.2.0"
+    "@adonisjs/core": "^6.2.0",
+    "@adonisjs/logger": "^6.0.3"
   },
   "publishConfig": {
     "access": "public",

--- a/providers/kafka_provider.ts
+++ b/providers/kafka_provider.ts
@@ -1,19 +1,6 @@
 import { ApplicationService, KafkaConfig } from '@adonisjs/core/types'
 
 import { Kafka } from '../src/index.ts'
-import { Producer } from '../src/producer.ts'
-
-import { HttpContext } from '@adonisjs/core/http'
-
-declare module '@adonisjs/core/http' {
-  export interface HttpContext {
-    kafka: {
-      producers: {
-        [key: string]: Producer
-      }
-    }
-  }
-}
 
 export default class KafkaProvider {
   private app: ApplicationService
@@ -32,18 +19,8 @@ export default class KafkaProvider {
   }
 
   async boot() {
-    if (this.config.enabled) {
-      const kafka = await this.app.container.make('kafka')
-      await kafka.start()
-
-      HttpContext.getter(
-        'kafka',
-        function (this: Request) {
-          return kafka
-        },
-        true
-      )
-    }
+    const kafka = await this.app.container.make('kafka')
+    await kafka.start()
   }
 
   async start() {
@@ -56,9 +33,7 @@ export default class KafkaProvider {
   }
 
   async shutdown() {
-    if (this.config.enabled) {
-      const kafka = await this.app.container.make('kafka')
-      kafka.disconnect()
-    }
+    const kafka = await this.app.container.make('kafka')
+    kafka.disconnect()
   }
 }

--- a/providers/kafka_provider.ts
+++ b/providers/kafka_provider.ts
@@ -4,17 +4,16 @@ import { Kafka } from '../src/index.ts'
 
 export default class KafkaProvider {
   private app: ApplicationService
-  private config: KafkaConfig
 
   constructor(app: ApplicationService) {
     this.app = app
-    this.config = this.app.config.get<KafkaConfig>('kafka')
   }
 
   register() {
     this.app.container.singleton('kafka', async () => {
       const logger = await this.app.container.make('logger')
-      return new Kafka(logger, this.config)
+      const config = this.app.config.get<KafkaConfig>('kafka')
+      return new Kafka(logger, config)
     })
   }
 
@@ -23,17 +22,8 @@ export default class KafkaProvider {
     await kafka.start()
   }
 
-  async start() {
-    try {
-      const startKafka = () => import(`${this.app.startPath()}/kafka.ts`)
-      startKafka()
-    } catch (e) {
-      console.log(e)
-    }
-  }
-
   async shutdown() {
     const kafka = await this.app.container.make('kafka')
-    kafka.disconnect()
+    await kafka.disconnect()
   }
 }

--- a/services/kafka.ts
+++ b/services/kafka.ts
@@ -1,4 +1,3 @@
-// import app from '@adonisjs/core/services/app'
 import app from '@adonisjs/core/services/app'
 import { Kafka } from '../src/index.ts'
 
@@ -10,7 +9,6 @@ let kafka: Kafka
  */
 await app.booted(async () => {
   kafka = await app.container.make('kafka')
-  await kafka.start()
 })
 
 export { kafka as default }

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -28,7 +28,7 @@ export class Consumer {
     this.consumer = kafka.consumer({ groupId: this.config.groupId })
   }
 
-  async execute(payload: EachMessagePayload, consumerRunConfig: ConsumerRunConfig) {
+  async execute(payload: EachMessagePayload) {
     const { topic, partition, message } = payload
     let result: any
     try {
@@ -52,10 +52,9 @@ export class Consumer {
         callback(
           result,
           async (commit = true) => {
-            if (consumerRunConfig.autoCommit) {
+            if (this.consumerRunConfig.autoCommit) {
               return resolve()
             }
-
             if (commit) {
               const offset = (Number(message.offset) + 1).toString()
               await this.consumer.commitOffsets([{ topic, partition, offset }])
@@ -83,9 +82,8 @@ export class Consumer {
     })
   }
 
-  // TODO: Have execute just use this.consumerRunConfig directly
   async eachMessage(payload: EachMessagePayload): Promise<void> {
-    await this.execute(payload, this.consumerRunConfig)
+    await this.execute(payload)
   }
 
   async on({ topic, fromBeginning }: ConsumerSubscribeTopic, callback: any) {

--- a/src/define_config.ts
+++ b/src/define_config.ts
@@ -2,14 +2,12 @@ import { KafkaConfig } from '@adonisjs/core/types'
 
 export function defineConfig(config = {}): KafkaConfig {
   return {
-    enabled: false,
+    brokers: 'localhost:9092',
     clientId: 'default-client',
     groupId: 'default-group',
-    url: 'localhost',
-    port: 9092,
     connectionTimeout: 3000,
     requestTimeout: 60000,
-    logLevel: 1,
+    logLevel: 'info',
     // Overwrite default config values if another one is provided
     ...config,
   }

--- a/src/define_config.ts
+++ b/src/define_config.ts
@@ -3,8 +3,7 @@ import { KafkaConfig } from '@adonisjs/core/types'
 export function defineConfig(config = {}): KafkaConfig {
   return {
     brokers: 'localhost:9092',
-    clientId: 'default-client',
-    groupId: 'default-group',
+    clientId: 'local',
     connectionTimeout: 3000,
     requestTimeout: 60000,
     logLevel: 'info',

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -1,0 +1,33 @@
+/**
+ * This is used to validate the start/env.ts for Kafka Brokers
+ */
+interface Validators {
+  brokers(): (key: string, value?: string) => string[]
+}
+
+interface KafkaEnv {
+  schema: Validators
+}
+
+export const KafkaEnv: KafkaEnv = {
+  schema: {
+    brokers() {
+      return (name: string, value?: string): string[] => {
+        if (!value) {
+          throw new Error(`value for $${name} is required`)
+        }
+
+        const urls = value.split(',')
+        const valid = urls.every((url) => {
+          return URL.canParse(url)
+        })
+
+        if (!valid) {
+          throw new Error(`Invalid URLs in $${name}`)
+        }
+
+        return urls
+      }
+    },
+  },
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,78 +1,96 @@
-import { Admin, Kafka as KafkaJs } from 'kafkajs'
+import { Kafka as KafkaJs } from 'kafkajs'
 import { type ProducerConfig, type ConsumerConfig } from 'kafkajs'
 
-import { type Logger } from '@adonisjs/core/logger'
+import type { Logger } from '@adonisjs/core/logger'
 import { ApplicationService, KafkaConfig, KafkaContract } from '@adonisjs/core/types'
 
 import { Consumer } from './consumer.ts'
 import { Producer } from './producer.ts'
 import { defineConfig } from './define_config.ts'
+import { type KafkaLogLevel, toAdonisLoggerLevel, toKafkaLogLevel } from './logging.ts'
 
 export class Kafka implements KafkaContract {
   protected application!: ApplicationService
 
-  consumers: Consumer[]
-  producers: {
+  #consumers: Consumer[]
+  #producers: {
     [key: string]: Producer
   }
-  kafka!: KafkaJs
-  config: KafkaConfig
-  Logger: Logger
-  admin?: Admin
 
-  constructor(Logger: Logger, config: KafkaConfig) {
-    this.config = defineConfig(config)
-    this.Logger = Logger
-    this.consumers = []
-    this.producers = {}
+  #kafka!: KafkaJs
+  #config: KafkaConfig
+  #logger: Logger
+
+  constructor(logger: Logger, config: KafkaConfig) {
+    this.#config = defineConfig(config)
+    this.#logger = logger.child({ module: 'kafka' })
+    this.#consumers = []
+    this.#producers = {}
   }
 
   async start() {
-    const { groupId } = this.config
-
-    if (groupId === null || groupId === undefined || groupId === '') {
-      throw new Error('You need define a group')
-    }
-
     this.createKafka()
   }
 
   createProducer(name: string, config: ProducerConfig) {
     // TODO: we probably have to break out consumer/producer option config types from KafkaConfig
-    if (this.producers[name]) {
+    if (this.#producers[name]) {
       throw new Error(`producer with name '${name}' already exists`)
     }
-    const producer = new Producer(this.kafka, config, this.config.enabled)
-    this.producers[name] = producer
+
+    const producer = new Producer(this.#kafka, config)
+    this.#producers[name] = producer
+
     return producer
   }
 
   createConsumer(config: ConsumerConfig) {
-    const consumer = new Consumer(this.kafka, config)
-    this.consumers.push(consumer)
+    const consumer = new Consumer(this.#kafka, {
+      ...config,
+      groupId: config.groupId ?? this.#config.groupId ?? 'local',
+    })
+
+    this.#consumers.push(consumer)
+
     return consumer
   }
 
-  private createKafka() {
-    const brokers = this.config.urls ? this.config.urls.split(',') : null
-
-    this.kafka = new KafkaJs({
-      clientId: this.config.clientId || 'local',
-      brokers: brokers || [`${this.config.url}:${this.config.port}`],
-      connectionTimeout: this.config.connectionTimeout,
-      requestTimeout: this.config.requestTimeout,
-      logLevel: this.config.logLevel,
-    })
-
-    if (this.kafka !== undefined) {
-      this.admin = this.kafka.admin()
-      this.admin.connect().catch((e) => this.Logger.error(`[admin] ${e.message}`, e))
+  private getBrokers() {
+    if (!this.#config.brokers) {
+      // This is the default host/port for Kafka:
+      return ['localhost:9092']
+    } else {
+      return Array.isArray(this.#config.brokers)
+        ? this.#config.brokers
+        : this.#config.brokers.split(',')
     }
   }
 
+  private createKafka() {
+    this.#kafka = new KafkaJs({
+      brokers: this.getBrokers(),
+      clientId: this.#config.clientId || 'local',
+      connectionTimeout: this.#config.connectionTimeout,
+      requestTimeout: this.#config.requestTimeout,
+      logLevel: toKafkaLogLevel(this.#config.logLevel),
+      logCreator: (logLevel: KafkaLogLevel) => {
+        this.#logger.level = toAdonisLoggerLevel(logLevel)
+
+        return ({ level, log, ...rest }) => {
+          const { message, timestamp, logger, ...extra } = log
+          this.#logger[toAdonisLoggerLevel(level)]({ ...rest, ...extra }, log.message)
+        }
+      },
+    })
+  }
+
   async disconnect() {
-    for await (let consumer of this.consumers) {
+    for await (let consumer of this.#consumers) {
       await consumer.consumer.disconnect()
+    }
+
+    for (let producer in this.#producers) {
+      await this.#producers[producer].producer.disconnect()
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,10 +45,7 @@ export class Kafka implements KafkaContract {
   }
 
   createConsumer(config: ConsumerConfig) {
-    const consumer = new Consumer(this.#kafka, {
-      ...config,
-      groupId: config.groupId ?? this.#config.groupId ?? 'local',
-    })
+    const consumer = new Consumer(this.#kafka, config)
 
     this.#consumers.push(consumer)
 
@@ -76,9 +73,11 @@ export class Kafka implements KafkaContract {
       logCreator: (logLevel: KafkaLogLevel) => {
         this.#logger.level = toAdonisLoggerLevel(logLevel)
 
-        return ({ level, log, ...rest }) => {
+        return ({ namespace, level, label: _label, log }) => {
           const { message, timestamp, logger, ...extra } = log
-          this.#logger[toAdonisLoggerLevel(level)]({ ...rest, ...extra }, log.message)
+          this.#logger
+            .child({ module: `kafka.${namespace}` })
+            [toAdonisLoggerLevel(level)]({ ...extra }, log.message)
         }
       },
     })

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,35 @@
+import { Level } from '@adonisjs/logger/types'
+import { logLevel } from 'kafkajs'
+
+export type KafkaLogLevel = logLevel
+
+export const toAdonisLoggerLevel = (level: KafkaLogLevel) => {
+  switch (level) {
+    case logLevel.ERROR:
+    case logLevel.NOTHING:
+      return 'error'
+    case logLevel.WARN:
+      return 'warn'
+    case logLevel.INFO:
+      return 'info'
+    case logLevel.DEBUG:
+      return 'debug'
+  }
+}
+
+export const toKafkaLogLevel = (level: Level) => {
+  switch (level) {
+    case 'debug':
+    case 'fatal':
+    case 'trace':
+      return logLevel.DEBUG
+    case 'error':
+      return logLevel.ERROR
+    case 'info':
+      return logLevel.INFO
+    case 'warn':
+      return logLevel.WARN
+    default:
+      return logLevel.INFO
+  }
+}

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -30,6 +30,6 @@ export const toKafkaLogLevel = (level: Level) => {
     case 'warn':
       return logLevel.WARN
     default:
-      return logLevel.INFO
+      return logLevel.NOTHING
   }
 }

--- a/src/producer.ts
+++ b/src/producer.ts
@@ -3,28 +3,18 @@ import { Kafka, Producer as KafkaProducer, type ProducerConfig } from 'kafkajs'
 export class Producer {
   config: ProducerConfig
   producer: KafkaProducer
-  enabled: boolean
 
-  constructor(kafka: Kafka, config: ProducerConfig, enabled: boolean) {
+  constructor(kafka: Kafka, config: ProducerConfig) {
     this.config = config
-    this.enabled = enabled
-
     this.producer = kafka.producer()
   }
 
   async start() {
-    if (!this.enabled) {
-      return
-    }
     await this.producer.connect()
     return this
   }
 
   async send(topic: string, data: any) {
-    if (!this.enabled) {
-      return
-    }
-
     if (typeof data !== 'object') {
       throw new Error('You need send a json object in data argument')
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,8 @@
-import { Kafka as KafkaJs, Admin } from 'kafkajs'
+import {
+  ProducerConfig as KafkaProducerConfig,
+  ConsumerConfig as KafkaConsumerConfig,
+} from 'kafkajs'
+import type { Level } from '@adonisjs/logger/types'
 import type { Consumer } from './consumer.ts'
 import type { Producer } from './producer.ts'
 
@@ -10,26 +14,19 @@ declare module '@adonisjs/core/types' {
   }
 
   export interface KafkaConfig {
-    enabled: boolean
-    clientId: string
-    groupId: string
-    url: string
-    port: number
-    urls?: string | null
+    brokers?: string | string[]
+    clientId?: string
+    groupId?: string
     connectionTimeout?: number
     requestTimeout?: number
-    logLevel: any
+    logLevel: Level
   }
 
   export interface KafkaContract {
     start: (...args: any[]) => void
     disconnect: () => void
-    consumers: Consumer[]
-    producers: {
-      [key: string]: Producer
-    }
-    kafka: KafkaJs
-    admin?: Admin
+    createProducer(name: string, config: KafkaProducerConfig): Producer
+    createConsumer(config: KafkaConsumerConfig): Consumer
   }
 }
 export * from 'kafkajs'

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,6 @@ declare module '@adonisjs/core/types' {
   export interface KafkaConfig {
     brokers?: string | string[]
     clientId?: string
-    groupId?: string
     connectionTimeout?: number
     requestTimeout?: number
     logLevel: Level

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import {
   ProducerConfig as KafkaProducerConfig,
   ConsumerConfig as KafkaConsumerConfig,
+  Message as KafkaMessage,
 } from 'kafkajs'
 import type { Level } from '@adonisjs/logger/types'
 import type { Consumer } from './consumer.ts'
@@ -28,4 +29,9 @@ declare module '@adonisjs/core/types' {
     createConsumer(config: KafkaConsumerConfig): Consumer
   }
 }
+
+export interface SendMessage extends KafkaMessage {
+  value: any
+}
+
 export * from 'kafkajs'

--- a/stubs/config/kafka.stub
+++ b/stubs/config/kafka.stub
@@ -5,15 +5,12 @@ import env from '#start/env'
 import app from '@adonisjs/core/services/app'
 
 const kafkaConfig = {
-  enabled: env.get('KAFKA_ENABLED', false),
-  clientId: env.get('KAFKA_CLIENT_ID', 'default-client'),
-  groupId: env.get('KAFKA_GROUP_ID', 'default-group'),
-  url: env.get('KAFKA_URL', 'localhost'),
-  port: env.get('KAFKA_PORT', 9092),
-  urls: env.get('KAFKA_URLS', null),
+  brokers: env.get('KAFKA_BROKERS', 'localhost:9092'),
+  clientId: env.get('KAFKA_CLIENT_ID', 'ccs-webhooks'),
+  groupId: env.get('KAFKA_GROUP_ID', 'ccs-webhooks'),
   connectionTimeout: env.get('KAFKA_CONNECTION_TIMEOUT', 3000),
   requestTimeout: env.get('KAFKA_REQUEST_TIMEOUT', 60000),
-  logLevel: env.get('KAFKA_LOG_LEVEL', 1),
+  logLevel: env.get('KAFKA_LOG_LEVEL', 'info'),
 }
 
 export default kafkaConfig

--- a/stubs/config/kafka.stub
+++ b/stubs/config/kafka.stub
@@ -2,15 +2,14 @@
       exports({ to: app.configPath('kafka.ts') })
 }}}
 import env from '#start/env'
-import app from '@adonisjs/core/services/app'
 
 const kafkaConfig = {
   brokers: env.get('KAFKA_BROKERS', 'localhost:9092'),
-  clientId: env.get('KAFKA_CLIENT_ID', 'ccs-webhooks'),
-  groupId: env.get('KAFKA_GROUP_ID', 'ccs-webhooks'),
+  clientId: env.get('KAFKA_CLIENT_ID'),
   connectionTimeout: env.get('KAFKA_CONNECTION_TIMEOUT', 3000),
   requestTimeout: env.get('KAFKA_REQUEST_TIMEOUT', 60000),
-  logLevel: env.get('KAFKA_LOG_LEVEL', 'info'),
+  logLevel: env.get('KAFKA_LOG_LEVEL', env.get('LOG_LEVEL')),
 }
 
 export default kafkaConfig
+

--- a/stubs/start/kafka.stub
+++ b/stubs/start/kafka.stub
@@ -3,24 +3,3 @@
 }}}
 import Kafka from "@neighbourhoodie/adonis-kafka/services/kafka"
 
-const consumer = Kafka.createConsumer({ groupId: 'default' })
-consumer.on({ topic: 'messages' }, (data: any, commit: any) => {
-  console.log('receiving in callback', data)
-  commit()
-})
-consumer.start({}) // ConsumerRunConfig
-
-// node ace make controller kafka/webhooks
-// import WebhooksController from "#controllers/kafka/webhooks_controller"
-// const consumer = Kafka.createConsumer({ groupId: 'default' })
-// consumer.on({ topic: 'messages' }, [WebhooksController, 'handleWebhook'])
-// consumer.start({}) // ConsumerRunConfig
-
-Kafka.createProducer('foo', {} /* ProducerConfig */).start()
-Kafka.createProducer('bar', {} /* ProducerConfig */).start()
-
-// in your route, you can now do:
-// router.get('/test', ( { kafka }: HttpContext)) => {
-//   await kafka.producer['foo'].send('msg', {yay: 1})
-//   return 'sent'
-// })

--- a/tests/consumer.spec.ts
+++ b/tests/consumer.spec.ts
@@ -162,7 +162,7 @@ test.group('Kafka Consumer', (group) => {
     await consumer.eachMessage(payload)
 
     assert.isTrue(execute.called)
-    assert.isTrue(execute.calledWith(payload, runConfig))
+    assert.isTrue(execute.calledWith(payload))
   })
 
   // technically an internal method, but still
@@ -172,9 +172,10 @@ test.group('Kafka Consumer', (group) => {
     })
 
     const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    sinon.replace(consumer.consumer, 'commitOffsets', sinon.spy())
     const callback = sinon.stub().callsArg(1)
     consumer.events['test'] = [callback]
-    const runConfig = {
+    consumer.consumerRunConfig = {
       autoCommit: true,
     }
     const message = {
@@ -185,10 +186,13 @@ test.group('Kafka Consumer', (group) => {
       offset: '1',
       headers: {},
     }
-    await consumer.execute(
-      { topic: 'test', partition: 1, message, heartbeat: sinon.spy(), pause: sinon.spy() },
-      runConfig
-    )
+    await consumer.execute({
+      topic: 'test',
+      partition: 1,
+      message,
+      heartbeat: sinon.spy(),
+      pause: sinon.spy(),
+    })
     assert.isTrue(callback.called)
   })
 
@@ -201,9 +205,7 @@ test.group('Kafka Consumer', (group) => {
     const consumer = new Consumer(kafkajs, { groupId: 'test' })
     const callback = sinon.stub().callsArg(1)
     consumer.events['test'] = [callback]
-    const runConfig = {
-      autoCommit: true,
-    }
+
     const message = {
       value: null,
       key: null,
@@ -212,10 +214,13 @@ test.group('Kafka Consumer', (group) => {
       offset: '1',
       headers: {},
     }
-    const result = await consumer.execute(
-      { topic: 'test', partition: 1, message, heartbeat: sinon.spy(), pause: sinon.spy() },
-      runConfig
-    )
+    const result = await consumer.execute({
+      topic: 'test',
+      partition: 1,
+      message,
+      heartbeat: sinon.spy(),
+      pause: sinon.spy(),
+    })
     assert.isFalse(callback.called)
     assert.isUndefined(result)
   })
@@ -231,9 +236,7 @@ test.group('Kafka Consumer', (group) => {
     consumer.events['test'] = [callback]
     const handler = sinon.spy()
     consumer.registerErrorHandler('test', handler)
-    const runConfig = {
-      autoCommit: true,
-    }
+
     const message = {
       value: Buffer.from('{.123}'),
       key: null,
@@ -242,10 +245,13 @@ test.group('Kafka Consumer', (group) => {
       offset: '1',
       headers: {},
     }
-    const result = await consumer.execute(
-      { topic: 'test', partition: 1, message, heartbeat: sinon.spy(), pause: sinon.spy() },
-      runConfig
-    )
+    const result = await consumer.execute({
+      topic: 'test',
+      partition: 1,
+      message,
+      heartbeat: sinon.spy(),
+      pause: sinon.spy(),
+    })
     assert.isFalse(callback.called)
     assert.isUndefined(result)
     assert.isTrue(handler.called)
@@ -262,7 +268,7 @@ test.group('Kafka Consumer', (group) => {
     const commitOffset = sinon.replace(consumer.consumer, 'commitOffsets', sinon.spy())
     const callback = sinon.stub().callsArgWith(1, true)
     consumer.events['test'] = [callback]
-    const runConfig = {
+    consumer.consumerRunConfig = {
       autoCommit: false,
     }
     const message = {
@@ -273,14 +279,14 @@ test.group('Kafka Consumer', (group) => {
       offset: '1',
       headers: {},
     }
-    await consumer.execute(
-      { topic: 'test', partition: 1, message, heartbeat: sinon.spy(), pause: sinon.spy() },
-      runConfig
-    )
-    assert.equal(callback.args[0][0], 123)
-    assert.equal(callback.args[0][2].topic, 'test')
-    assert.isFunction(callback.args[0][2].heartbeat)
-    assert.isFunction(callback.args[0][2].pause)
+    await consumer.execute({
+      topic: 'test',
+      partition: 1,
+      message,
+      heartbeat: sinon.spy(),
+      pause: sinon.spy(),
+    })
+    assert.isTrue(callback.called)
     assert.isTrue(commitOffset.called)
     assert.isTrue(
       commitOffset.calledWith([
@@ -307,7 +313,7 @@ test.group('Kafka Consumer', (group) => {
       await commit(true)
     })
     consumer.events['test'] = [callback]
-    const runConfig = {
+    consumer.consumerRunConfig = {
       autoCommit: true,
     }
     const message = {
@@ -320,7 +326,7 @@ test.group('Kafka Consumer', (group) => {
     }
     const heartbeat = sinon.spy()
     const pause = sinon.spy()
-    await consumer.execute({ topic: 'test', partition: 1, message, heartbeat, pause }, runConfig)
+    await consumer.execute({ topic: 'test', partition: 1, message, heartbeat, pause })
     assert.isTrue(heartbeat.called)
     assert.isTrue(pause.called)
   })

--- a/tests/consumer.spec.ts
+++ b/tests/consumer.spec.ts
@@ -125,6 +125,46 @@ test.group('Kafka Consumer', (group) => {
     assert.isTrue(handler3.calledWith(error3))
   })
 
+  test('eachMessage', async ({ assert }) => {
+    const kafkajs = new Kafkajs({
+      brokers: ['asd'],
+    })
+
+    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    // const callback = sinon.stub().callsArg(1)
+    // consumer.events['test'] = [callback]
+
+    const runConfig = {
+      autoCommit: true,
+    }
+
+    consumer.consumerRunConfig = runConfig
+
+    const execute = sinon.spy(consumer, 'execute')
+
+    const message = {
+      value: Buffer.from('{"foo":1}'),
+      key: null,
+      timestamp: '2024-05-03',
+      attributes: 0,
+      offset: '1',
+      headers: {},
+    }
+
+    const payload = {
+      topic: 'test',
+      partition: 1,
+      message,
+      heartbeat: sinon.spy(),
+      pause: sinon.spy(),
+    }
+
+    await consumer.eachMessage(payload)
+
+    assert.isTrue(execute.called)
+    assert.isTrue(execute.calledWith(payload, runConfig))
+  })
+
   // technically an internal method, but still
   test('execute', async ({ assert }) => {
     const kafkajs = new Kafkajs({

--- a/tests/logging.spec.ts
+++ b/tests/logging.spec.ts
@@ -1,0 +1,60 @@
+import { test } from '@japa/runner'
+import { Level } from '@adonisjs/logger/types'
+import { logLevel } from 'kafkajs'
+
+import { toAdonisLoggerLevel, toKafkaLogLevel } from '../src/logging.ts'
+
+test.group('Logging: toAdonisLoggerLevel', () => {
+  test('with logLevel.ERROR', async ({ assert }) => {
+    const newLevel = toAdonisLoggerLevel(logLevel.ERROR)
+    assert.equal(newLevel, 'error')
+  })
+  test('with logLevel.NOTHING', async ({ assert }) => {
+    const newLevel = toAdonisLoggerLevel(logLevel.NOTHING)
+    assert.equal(newLevel, 'error')
+  })
+  test('with logLevel.WARN', async ({ assert }) => {
+    const newLevel = toAdonisLoggerLevel(logLevel.WARN)
+    assert.equal(newLevel, 'warn')
+  })
+  test('with logLevel.INFO', async ({ assert }) => {
+    const newLevel = toAdonisLoggerLevel(logLevel.INFO)
+    assert.equal(newLevel, 'info')
+  })
+  test('with logLevel.DEBUG', async ({ assert }) => {
+    const newLevel = toAdonisLoggerLevel(logLevel.DEBUG)
+    assert.equal(newLevel, 'debug')
+  })
+})
+
+test.group('Logging: toKafkaLogLevel', () => {
+  test('with Level of fatal', async ({ assert }) => {
+    const newLevel = toKafkaLogLevel('fatal')
+    assert.equal(newLevel, logLevel.DEBUG)
+  })
+  test('with Level of trace', async ({ assert }) => {
+    const newLevel = toKafkaLogLevel('trace')
+    assert.equal(newLevel, logLevel.DEBUG)
+  })
+  test('with Level of debug', async ({ assert }) => {
+    const newLevel = toKafkaLogLevel('debug')
+    assert.equal(newLevel, logLevel.DEBUG)
+  })
+  test('with Level of error', async ({ assert }) => {
+    const newLevel = toKafkaLogLevel('error')
+    assert.equal(newLevel, logLevel.ERROR)
+  })
+  test('with Level of warn', async ({ assert }) => {
+    const newLevel = toKafkaLogLevel('warn')
+    assert.equal(newLevel, logLevel.WARN)
+  })
+  test('with Level of info', async ({ assert }) => {
+    const newLevel = toKafkaLogLevel('info')
+    assert.equal(newLevel, logLevel.INFO)
+  })
+  test('with Level of unknown', async ({ assert }) => {
+    // unknown isn't actually a Pino.Level, hence the as cast:
+    const newLevel = toKafkaLogLevel('unknown' as Level)
+    assert.equal(newLevel, logLevel.NOTHING)
+  })
+})

--- a/tests/producer.spec.ts
+++ b/tests/producer.spec.ts
@@ -14,9 +14,9 @@ test.group('Kafka Producer', (group) => {
     const kafkajs = new Kafkajs({
       brokers: ['asd'],
     })
-    const enabled = true
+
     const producer = sinon.spy(kafkajs, 'producer')
-    new Producer(kafkajs, {}, enabled)
+    new Producer(kafkajs, {})
     assert.isTrue(producer.called)
   })
 
@@ -25,8 +25,7 @@ test.group('Kafka Producer', (group) => {
       brokers: ['asd'],
     })
 
-    const enabled = true
-    const producer = new Producer(kafkajs, {}, enabled)
+    const producer = new Producer(kafkajs, {})
     const connect = sinon.replace(producer.producer, 'connect', sinon.fake())
     await producer.start()
 
@@ -34,40 +33,12 @@ test.group('Kafka Producer', (group) => {
     assert.equal(connect.callCount, 1)
   })
 
-  test('start disabled', async ({ assert }) => {
-    const kafkajs = new Kafkajs({
-      brokers: ['asd'],
-    })
-
-    const enabled = false
-    const producer = new Producer(kafkajs, {}, enabled)
-    const connect = sinon.replace(producer.producer, 'connect', sinon.fake())
-    await producer.start()
-
-    assert.isFalse(connect.called)
-  })
-
-  test('send disabled', async ({ assert }) => {
-    const kafkajs = new Kafkajs({
-      brokers: ['asd'],
-    })
-
-    const enabled = false
-    const producer = new Producer(kafkajs, {}, enabled)
-    const send = sinon.replace(producer.producer, 'send', sinon.fake())
-
-    const result = await producer.send('foo', 'bar')
-    assert.isUndefined(result)
-    assert.isFalse(send.called)
-  })
-
   test('send wrong type', async ({ assert }) => {
     const kafkajs = new Kafkajs({
       brokers: ['asd'],
     })
 
-    const enabled = true
-    const producer = new Producer(kafkajs, {}, enabled)
+    const producer = new Producer(kafkajs, {})
     const send = sinon.replace(producer.producer, 'send', sinon.fake())
 
     assert.rejects(async () => producer.send('foo', 123))
@@ -79,8 +50,7 @@ test.group('Kafka Producer', (group) => {
       brokers: ['asd'],
     })
 
-    const enabled = true
-    const producer = new Producer(kafkajs, {}, enabled)
+    const producer = new Producer(kafkajs, {})
     const send = sinon.replace(producer.producer, 'send', sinon.fake())
 
     await producer.send('foo', { bar: 'baz' })
@@ -92,8 +62,7 @@ test.group('Kafka Producer', (group) => {
       brokers: ['asd'],
     })
 
-    const enabled = true
-    const producer = new Producer(kafkajs, {}, enabled)
+    const producer = new Producer(kafkajs, {})
     const send = sinon.replace(producer.producer, 'send', sinon.fake())
 
     await producer.send('foo', { value: 123 })
@@ -105,8 +74,7 @@ test.group('Kafka Producer', (group) => {
       brokers: ['asd'],
     })
 
-    const enabled = true
-    const producer = new Producer(kafkajs, {}, enabled)
+    const producer = new Producer(kafkajs, {})
     const send = sinon.replace(producer.producer, 'send', sinon.fake())
 
     await producer.send('foo', [{ value: 123 }, { bar: 'baz' }])


### PR DESCRIPTION
The custom `KafkaEnv` validator / codemod here outputs the following:

```
import { Env } from '@adonisjs/core/env'
import { KafkaEnv } from '@neighbourhoodie/adonis-kafka/env'

export default await Env.create(new URL('../', import.meta.url), {
  NODE_ENV: Env.schema.enum(['development', 'production', 'test'] as const),
  PORT: Env.schema.number(),
  APP_KEY: Env.schema.string(),
  HOST: Env.schema.string({ format: 'host' }),
  LOG_LEVEL: Env.schema.string(),

  /*
  |----------------------------------------------------------
  | Variables for configuring kafka package
  |----------------------------------------------------------
  */
  KAFKA_BROKERS: KafkaEnv.schema.brokers(),
  KAFKA_CLIENT_ID: Env.schema.string.optional(),
  KAFKA_GROUP_ID: Env.schema.string.optional(),
  KAFKA_CONNECTION_TIMEOUT: Env.schema.number.optional(),
  KAFKA_REQUEST_TIMEOUT: Env.schema.number.optional(),
  KAFKA_LOG_LEVEL: Env.schema.enum.optional(['fatal', 'error', 'warn', 'info', 'debug', 'trace']),
})
```

Notice how it adds a named import and then uses it for `KAFKA_BROKERS`? Pretty cool, huh?