### PR TITLE
Feature: auto start producers and consumers

### DIFF
--- a/providers/kafka_provider.ts
+++ b/providers/kafka_provider.ts
@@ -1,8 +1,9 @@
 import { ApplicationService, KafkaConfig } from '@adonisjs/core/types'
+import { ContainerProviderContract } from '@adonisjs/core/types/app'
 
 import { Kafka } from '../src/index.ts'
 
-export default class KafkaProvider {
+export default class KafkaProvider implements ContainerProviderContract {
   private app: ApplicationService
 
   constructor(app: ApplicationService) {
@@ -20,6 +21,22 @@ export default class KafkaProvider {
   async boot() {
     const kafka = await this.app.container.make('kafka')
     await kafka.start()
+  }
+
+  // Has to be ready to make use of preloads:
+  async ready() {
+    const logger = await this.app.container.make('logger')
+    const kafka = await this.app.container.make('kafka')
+
+    logger.debug({ consumers: kafka.consumers, producers: kafka.producers })
+
+    for (const producer in kafka.producers) {
+      await kafka.producers[producer].start()
+    }
+
+    for (const consumer of kafka.consumers) {
+      await consumer.start()
+    }
   }
 
   async shutdown() {

--- a/providers/kafka_provider.ts
+++ b/providers/kafka_provider.ts
@@ -14,7 +14,7 @@ export default class KafkaProvider implements ContainerProviderContract {
     this.app.container.singleton('kafka', async () => {
       const logger = await this.app.container.make('logger')
       const config = this.app.config.get<KafkaConfig>('kafka')
-      return new Kafka(logger, config)
+      return new Kafka(config, logger)
     })
   }
 
@@ -25,10 +25,7 @@ export default class KafkaProvider implements ContainerProviderContract {
 
   // Has to be ready to make use of preloads:
   async ready() {
-    const logger = await this.app.container.make('logger')
     const kafka = await this.app.container.make('kafka')
-
-    logger.debug({ consumers: kafka.consumers, producers: kafka.producers })
 
     for (const producer in kafka.producers) {
       await kafka.producers[producer].start()

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -8,8 +8,6 @@ export class Consumer {
   topics: string[]
   events: any
   errorHandlers: any
-  killContainer: boolean
-  timeout: any = 0
   consumer: KafkaConsumer
 
   constructor(kafka: Kafka, config: ConsumerGroupConfig) {
@@ -17,8 +15,6 @@ export class Consumer {
     this.topics = []
     this.events = {}
     this.errorHandlers = {}
-    this.killContainer = false
-    this.timeout = null
 
     this.consumer = kafka.consumer(this.config)
   }

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -16,16 +16,16 @@ export class Consumer {
   consumer: KafkaConsumer
   consumerRunConfig: ConsumerRunConfig
 
-  constructor(kafka: Kafka, config: any) {
+  constructor(kafka: Kafka, config: ConsumerConfig, consumerRunConfig: ConsumerRunConfig) {
     this.config = config
     this.topics = []
     this.events = {}
     this.errorHandlers = {}
     this.killContainer = false
     this.timeout = null
-    this.consumerRunConfig = {}
+    this.consumerRunConfig = consumerRunConfig
 
-    this.consumer = kafka.consumer({ groupId: this.config.groupId })
+    this.consumer = kafka.consumer(this.config)
   }
 
   async execute(payload: EachMessagePayload) {
@@ -70,15 +70,12 @@ export class Consumer {
     await Promise.all(promises)
   }
 
-  async start(consumerRunConfig: ConsumerRunConfig = {}) {
-    this.consumerRunConfig = consumerRunConfig
-
+  async start() {
     await this.consumer.connect()
 
     await this.consumer.run({
-      partitionsConsumedConcurrently: consumerRunConfig.partitionsConsumedConcurrently,
-      autoCommit: consumerRunConfig.autoCommit,
-      eachMessage: this.eachMessage,
+      ...this.consumerRunConfig,
+      eachMessage: this.eachMessage.bind(this),
     })
   }
 

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -1,7 +1,7 @@
 import { Kafka, Consumer as KafkaConsumer } from 'kafkajs'
-import { type EachMessagePayload } from 'kafkajs'
+import { type EachMessagePayload, type ConsumerSubscribeTopic } from 'kafkajs'
 
-import { ConsumerGroupConfig, ConsumerSubscribeTopics, ConsumerSubscribeTopic } from './types.ts'
+import { ConsumerGroupConfig } from './types.ts'
 
 export class Consumer {
   config: ConsumerGroupConfig

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -21,13 +21,14 @@ export class Consumer {
     this.consumer = kafka.consumer(this.config)
   }
 
-  async execute(payload: EachMessagePayload) {
+  async eachMessage(payload: EachMessagePayload): Promise<void> {
     const { topic, partition, message } = payload
+
     let result: any
     try {
       if (!message.value) {
         return
-      } // TODO Log?
+      }
       result = JSON.parse(message.value.toString())
     } catch (error) {
       this.raiseError(topic, error)
@@ -88,10 +89,6 @@ export class Consumer {
     }
 
     return this
-  }
-
-  async eachMessage(payload: EachMessagePayload): Promise<void> {
-    await this.execute(payload)
   }
 
   async on({ topic, fromBeginning }: ConsumerSubscribeTopic, callback: any) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export class Kafka implements KafkaContract {
   #config: KafkaConfig
   #logger: Logger
 
-  constructor(logger: Logger, config: KafkaConfig) {
+  constructor(config: KafkaConfig, logger: Logger) {
     this.#config = defineConfig(config)
     this.#logger = logger.child({ module: 'kafka' })
     this.#consumers = []
@@ -92,11 +92,11 @@ export class Kafka implements KafkaContract {
 
   async disconnect() {
     for await (let consumer of this.#consumers) {
-      await consumer.consumer.disconnect()
+      await consumer.stop()
     }
 
     for (let producer in this.#producers) {
-      await this.#producers[producer].producer.disconnect()
+      await this.#producers[producer].stop()
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,12 @@
 import { Kafka as KafkaJs } from 'kafkajs'
-import { type ProducerConfig, type ConsumerConfig } from 'kafkajs'
-
 import type { Logger } from '@adonisjs/core/logger'
 import { ApplicationService, KafkaConfig, KafkaContract } from '@adonisjs/core/types'
 
+import type { ProducerConfig, ConsumerGroupConfig } from './types.ts'
 import { Consumer } from './consumer.ts'
 import { Producer } from './producer.ts'
 import { defineConfig } from './define_config.ts'
 import { type KafkaLogLevel, toAdonisLoggerLevel, toKafkaLogLevel } from './logging.ts'
-import { ConsumerRunConfig } from './types.ts'
 
 export class Kafka implements KafkaContract {
   protected application!: ApplicationService
@@ -33,8 +31,7 @@ export class Kafka implements KafkaContract {
     this.createKafka()
   }
 
-  createProducer(name: string, config: ProducerConfig) {
-    // TODO: we probably have to break out consumer/producer option config types from KafkaConfig
+  createProducer(name: string, config: ProducerConfig = {}) {
     if (this.#producers[name]) {
       throw new Error(`producer with name '${name}' already exists`)
     }
@@ -45,8 +42,9 @@ export class Kafka implements KafkaContract {
     return producer
   }
 
-  createConsumer(config: ConsumerConfig, runConfig?: ConsumerRunConfig) {
-    const consumer = new Consumer(this.#kafka, config, runConfig ?? {})
+  createConsumer(config: ConsumerGroupConfig) {
+    // TODO: Assert that consumers have different groupId's
+    const consumer = new Consumer(this.#kafka, config)
 
     this.#consumers.push(consumer)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { Consumer } from './consumer.ts'
 import { Producer } from './producer.ts'
 import { defineConfig } from './define_config.ts'
 import { type KafkaLogLevel, toAdonisLoggerLevel, toKafkaLogLevel } from './logging.ts'
+import { ConsumerRunConfig } from './types.ts'
 
 export class Kafka implements KafkaContract {
   protected application!: ApplicationService
@@ -44,12 +45,20 @@ export class Kafka implements KafkaContract {
     return producer
   }
 
-  createConsumer(config: ConsumerConfig) {
-    const consumer = new Consumer(this.#kafka, config)
+  createConsumer(config: ConsumerConfig, runConfig?: ConsumerRunConfig) {
+    const consumer = new Consumer(this.#kafka, config, runConfig ?? {})
 
     this.#consumers.push(consumer)
 
     return consumer
+  }
+
+  get producers() {
+    return this.#producers
+  }
+
+  get consumers() {
+    return this.#consumers
   }
 
   private getBrokers() {

--- a/src/producer.ts
+++ b/src/producer.ts
@@ -4,16 +4,24 @@ import { SendMessage } from './types.ts'
 
 export class Producer {
   producer: KafkaProducer
-  #started: boolean
+  #started: boolean = false
 
   constructor(kafka: Kafka, config: ProducerConfig = {}) {
     this.producer = kafka.producer(config)
-    this.#started = false
   }
 
   async start() {
     if (!this.#started) {
       await this.producer.connect()
+      this.#started = true
+    }
+
+    return this
+  }
+
+  async stop() {
+    if (this.#started) {
+      await this.producer.disconnect()
     }
 
     return this

--- a/src/producer.ts
+++ b/src/producer.ts
@@ -6,7 +6,7 @@ export class Producer {
   producer: KafkaProducer
   #started: boolean
 
-  constructor(kafka: Kafka, config: ProducerConfig) {
+  constructor(kafka: Kafka, config: ProducerConfig = {}) {
     this.producer = kafka.producer(config)
     this.#started = false
   }

--- a/src/producer.ts
+++ b/src/producer.ts
@@ -4,13 +4,18 @@ import { SendMessage } from './types.ts'
 
 export class Producer {
   producer: KafkaProducer
+  #started: boolean
 
   constructor(kafka: Kafka, config: ProducerConfig) {
     this.producer = kafka.producer(config)
+    this.#started = false
   }
 
   async start() {
-    await this.producer.connect()
+    if (!this.#started) {
+      await this.producer.connect()
+    }
+
     return this
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,9 +26,11 @@ declare module '@adonisjs/core/types' {
     start: (...args: any[]) => void
     disconnect: () => void
     createProducer(name: string, config: KafkaProducerConfig): Producer
-    createConsumer(config: KafkaConsumerConfig): Consumer
+    createConsumer(config: KafkaConsumerConfig, runConfig: ConsumerRunConfig): Consumer
   }
 }
+
+export type ConsumerRunConfig = Omit<KafkaConsumerRunConfig, 'eachMessage' | 'eachBatch'>
 
 export interface SendMessage extends KafkaMessage {
   value: any

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
-import {
-  ProducerConfig as KafkaProducerConfig,
+import type {
   ConsumerConfig as KafkaConsumerConfig,
+  ProducerConfig as KafkaProducerConfig,
+  ConsumerRunConfig as KafkaConsumerRunConfig,
   Message as KafkaMessage,
 } from 'kafkajs'
 import type { Level } from '@adonisjs/logger/types'
@@ -8,6 +9,11 @@ import type { Consumer } from './consumer.ts'
 import type { Producer } from './producer.ts'
 
 import { Kafka } from './index.ts'
+
+export type ProducerConfig = KafkaProducerConfig
+
+export type ConsumerGroupConfig = KafkaConsumerConfig &
+  Omit<KafkaConsumerRunConfig, 'eachMessage' | 'eachBatch'>
 
 declare module '@adonisjs/core/types' {
   export interface ContainerBindings {
@@ -25,12 +31,10 @@ declare module '@adonisjs/core/types' {
   export interface KafkaContract {
     start: (...args: any[]) => void
     disconnect: () => void
-    createProducer(name: string, config: KafkaProducerConfig): Producer
-    createConsumer(config: KafkaConsumerConfig, runConfig: ConsumerRunConfig): Consumer
+    createProducer(name: string, config?: ProducerConfig): Producer
+    createConsumer(config: ConsumerGroupConfig): Consumer
   }
 }
-
-export type ConsumerRunConfig = Omit<KafkaConsumerRunConfig, 'eachMessage' | 'eachBatch'>
 
 export interface SendMessage extends KafkaMessage {
   value: any

--- a/tests/consumer.spec.ts
+++ b/tests/consumer.spec.ts
@@ -131,10 +131,7 @@ test.group('Kafka Consumer', (group) => {
     })
 
     const consumer = new Consumer(kafkajs, { groupId: 'test', autoCommit: false })
-    // const callback = sinon.stub().callsArg(1)
-    // consumer.events['test'] = [callback]
-
-    const execute = sinon.spy(consumer, 'execute')
+    const eachMessage = sinon.spy(consumer, 'eachMessage')
 
     const message = {
       value: Buffer.from('{"foo":1}'),
@@ -155,12 +152,12 @@ test.group('Kafka Consumer', (group) => {
 
     await consumer.eachMessage(payload)
 
-    assert.isTrue(execute.called)
-    assert.isTrue(execute.calledWith(payload))
+    assert.isTrue(eachMessage.called)
+    assert.isTrue(eachMessage.calledWith(payload))
   })
 
   // technically an internal method, but still
-  test('execute', async ({ assert }) => {
+  test('eachMessage via events', async ({ assert }) => {
     const kafkajs = new Kafkajs({
       brokers: ['asd'],
     })
@@ -178,7 +175,7 @@ test.group('Kafka Consumer', (group) => {
       offset: '1',
       headers: {},
     }
-    await consumer.execute({
+    await consumer.eachMessage({
       topic: 'test',
       partition: 1,
       message,
@@ -206,7 +203,7 @@ test.group('Kafka Consumer', (group) => {
       offset: '1',
       headers: {},
     }
-    const result = await consumer.execute({
+    const result = await consumer.eachMessage({
       topic: 'test',
       partition: 1,
       message,
@@ -237,7 +234,7 @@ test.group('Kafka Consumer', (group) => {
       offset: '1',
       headers: {},
     }
-    const result = await consumer.execute({
+    const result = await consumer.eachMessage({
       topic: 'test',
       partition: 1,
       message,
@@ -269,7 +266,7 @@ test.group('Kafka Consumer', (group) => {
       offset: '1',
       headers: {},
     }
-    await consumer.execute({
+    await consumer.eachMessage({
       topic: 'test',
       partition: 1,
       message,
@@ -314,7 +311,7 @@ test.group('Kafka Consumer', (group) => {
     }
     const heartbeat = sinon.spy()
     const pause = sinon.spy()
-    await consumer.execute({ topic: 'test', partition: 1, message, heartbeat, pause })
+    await consumer.eachMessage({ topic: 'test', partition: 1, message, heartbeat, pause })
     assert.isTrue(heartbeat.called)
     assert.isTrue(pause.called)
   })

--- a/tests/consumer.spec.ts
+++ b/tests/consumer.spec.ts
@@ -130,15 +130,9 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new Consumer(kafkajs, { groupId: 'test', autoCommit: false })
     // const callback = sinon.stub().callsArg(1)
     // consumer.events['test'] = [callback]
-
-    const runConfig = {
-      autoCommit: true,
-    }
-
-    consumer.consumerRunConfig = runConfig
 
     const execute = sinon.spy(consumer, 'execute')
 
@@ -171,13 +165,11 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new Consumer(kafkajs, { groupId: 'test', autoCommit: true })
     sinon.replace(consumer.consumer, 'commitOffsets', sinon.spy())
     const callback = sinon.stub().callsArg(1)
     consumer.events['test'] = [callback]
-    consumer.consumerRunConfig = {
-      autoCommit: true,
-    }
+
     const message = {
       value: Buffer.from('{"foo":1}'),
       key: null,
@@ -264,13 +256,11 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new Consumer(kafkajs, { groupId: 'test', autoCommit: false })
     const commitOffset = sinon.replace(consumer.consumer, 'commitOffsets', sinon.spy())
     const callback = sinon.stub().callsArgWith(1, true)
     consumer.events['test'] = [callback]
-    consumer.consumerRunConfig = {
-      autoCommit: false,
-    }
+
     const message = {
       value: Buffer.from('123'),
       key: null,
@@ -313,9 +303,7 @@ test.group('Kafka Consumer', (group) => {
       await commit(true)
     })
     consumer.events['test'] = [callback]
-    consumer.consumerRunConfig = {
-      autoCommit: true,
-    }
+
     const message = {
       value: Buffer.from('123'),
       key: null,

--- a/tests/producer.spec.ts
+++ b/tests/producer.spec.ts
@@ -17,7 +17,7 @@ test.group('Kafka Producer', (group) => {
     })
 
     const producer = sinon.spy(kafkajs, 'producer')
-    new Producer(kafkajs, {})
+    new Producer(kafkajs)
     assert.isTrue(producer.called)
   })
 

--- a/tests/provider.spec.ts
+++ b/tests/provider.spec.ts
@@ -26,7 +26,6 @@ test.group('Kafka Provider', () => {
             groupId: '123',
             clientId: '123',
             brokers: ['localhost:1232'],
-            enabled: false,
           },
         },
       })
@@ -44,17 +43,134 @@ test.group('Kafka Provider', () => {
     const { default: kafkaService } = await import('../services/kafka.ts')
     assert.instanceOf(kafkaService, Kafka)
 
-    const producer = kafkaService.createProducer('test', {})
+    const producer = kafkaService.createProducer('test')
     assert.instanceOf(producer, Producer)
 
     const consumer = kafkaService.createConsumer({
       groupId: 'test',
+      autoCommit: false,
     })
     assert.instanceOf(consumer, Consumer)
 
-    const disconnect = sinon.replace(kafka, 'disconnect', sinon.fake())
+    const consumerStart = sinon.spy(consumer, 'start')
+    const producerStart = sinon.spy(producer, 'start')
+
+    const producerConnect = sinon.replace(producer.producer, 'connect', sinon.fake())
+
+    const consumerConnect = sinon.replace(consumer.consumer, 'connect', sinon.fake())
+    const consumerRun = sinon.replace(consumer.consumer, 'run', sinon.fake())
+
+    let started = false
+    await app.start(async () => {
+      started = true
+    })
+
+    assert.isTrue(started, 'Application started')
+
+    assert.isTrue(producerStart.called)
+    assert.isTrue(producerConnect.called, 'consumer connect is called')
+
+    assert.isTrue(consumerStart.called)
+    assert.isTrue(consumerConnect.called, 'consumer connect is called')
+    assert.isTrue(consumerRun.called, 'consumer run is called')
+
+    assert.equal(producerStart.callCount, 1)
+    assert.equal(consumerStart.callCount, 1)
+
+    const consumerStop = sinon.spy(consumer, 'stop')
+    const consumerDisconnect = sinon.replace(consumer.consumer, 'disconnect', sinon.fake())
+    const producerStop = sinon.spy(producer, 'stop')
+    const producerDisconnect = sinon.replace(producer.producer, 'disconnect', sinon.fake())
+
+    const disconnect = sinon.spy(kafka, 'disconnect')
+
+    await app.terminate()
+    assert.isTrue(disconnect.called, 'kafka.disconnect called')
+    assert.isTrue(consumerStop.called, 'consumer.stop called')
+    assert.isTrue(producerStop.called, 'producer.stop called')
+
+    assert.isTrue(consumerDisconnect.called, 'consumer.consumer.disconnect called')
+    assert.isTrue(producerDisconnect.called, 'producer.producer.disconnect called')
+  })
+
+  test('shutdown before startup completes', async ({ assert }) => {
+    const ignitor = new IgnitorFactory()
+      .merge({
+        rcFileContents: {
+          providers: [() => import('../providers/kafka_provider.ts')],
+        },
+      })
+      .withCoreConfig()
+      .withCoreProviders()
+      .merge({
+        config: {
+          kafka: {
+            groupId: '123',
+            clientId: '123',
+            brokers: ['localhost:1232'],
+          },
+        },
+      })
+      .create(BASE_URL)
+
+    const app = ignitor.createApp('web')
+    await app.init()
+    await app.boot()
+
+    assert.isTrue(app.container.hasBinding('kafka'))
+
+    const kafka = await app.container.make('kafka')
+    assert.instanceOf(kafka, Kafka)
+
+    const producer = kafka.createProducer('test')
+    const consumer = kafka.createConsumer({
+      groupId: 'test',
+      autoCommit: false,
+    })
+
+    const consumerStop = sinon.spy(consumer, 'stop')
+    const consumerDisconnect = sinon.replace(consumer.consumer, 'disconnect', sinon.fake())
+    const producerStop = sinon.spy(producer, 'stop')
+    const producerDisconnect = sinon.replace(producer.producer, 'disconnect', sinon.fake())
+
+    const disconnect = sinon.spy(kafka, 'disconnect')
 
     await app.terminate()
     assert.isTrue(disconnect.called)
+    assert.isTrue(consumerStop.called)
+    assert.isTrue(producerStop.called)
+
+    assert.isFalse(consumerDisconnect.called)
+    assert.isFalse(producerDisconnect.called)
+  })
+
+  test('duplicate producers', async ({ assert }) => {
+    const ignitor = new IgnitorFactory()
+      .merge({
+        rcFileContents: {
+          providers: [() => import('../providers/kafka_provider.ts')],
+        },
+      })
+      .withCoreConfig()
+      .withCoreProviders()
+      .merge({
+        config: {
+          kafka: {
+            groupId: '123',
+            clientId: '123',
+            brokers: ['localhost:1232'],
+          },
+        },
+      })
+      .create(BASE_URL)
+
+    const app = ignitor.createApp('web')
+    await app.init()
+    await app.boot()
+
+    const kafka = await app.container.make('kafka')
+
+    assert.doesNotReject(() => kafka.createProducer('test'))
+    assert.rejects(() => kafka.createProducer('test'))
   })
 })


### PR DESCRIPTION
This implements all the logic for automatically starting any consumers or producers registered in the preload file (`#start/kafka.ts`), and ensures shutdown happens correctly.