### PR TITLE
Feature: improve callback signatures

### DIFF
--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -1,13 +1,18 @@
 import { Kafka, Consumer as KafkaConsumer } from 'kafkajs'
-import { type EachMessagePayload, type ConsumerSubscribeTopic } from 'kafkajs'
+import { type EachMessagePayload } from 'kafkajs'
 
-import { ConsumerGroupConfig } from './types.ts'
+import type {
+  ConsumerGroupConfig,
+  ConsumerSubscribeTopics,
+  ConsumerSubscribeTopic,
+  ConsumerErrorHandler,
+} from './types.ts'
 
 export class Consumer {
   config: ConsumerGroupConfig
   topics: string[]
   events: any
-  errorHandlers: any
+  errorHandlers: Record<string, ConsumerErrorHandler[]>
   consumer: KafkaConsumer
 
   #started: boolean = false
@@ -124,12 +129,12 @@ export class Consumer {
 
   raiseError(topic: string, error: Error) {
     const handlers = this.errorHandlers[topic] || []
-    handlers.forEach((handler: any) => {
+    handlers.forEach((handler) => {
       handler(error)
     })
   }
 
-  registerErrorHandler(topic: string, callback: any) {
+  onError(topic: string, callback: ConsumerErrorHandler) {
     //TODO add resolveCallback
     const handlers = this.errorHandlers[topic] || []
     handlers.push(callback)

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -6,12 +6,14 @@ import type {
   ConsumerSubscribeTopics,
   ConsumerSubscribeTopic,
   ConsumerErrorHandler,
+  ConsumerCallback,
+  ConsumerCommitCallback,
 } from './types.ts'
 
 export class Consumer {
   config: ConsumerGroupConfig
   topics: string[]
-  events: any
+  events: Record<string, ConsumerCallback[]>
   errorHandlers: Record<string, ConsumerErrorHandler[]>
   consumer: KafkaConsumer
 
@@ -27,7 +29,7 @@ export class Consumer {
   }
 
   async eachMessage(payload: EachMessagePayload): Promise<void> {
-    const { topic, partition, message } = payload
+    const { topic, partition, message, heartbeat, pause } = payload
 
     let result: any
     try {
@@ -36,33 +38,49 @@ export class Consumer {
       }
       result = JSON.parse(message.value.toString())
     } catch (error) {
-      this.raiseError(topic, error)
+      this.handleError(topic, error)
       return
     }
 
-    const events = this.events[topic]
+    const callbacks = this.events[topic]
 
-    if (!events || !events.length) {
+    if (!callbacks || !callbacks.length) {
       return
     }
 
-    const promises = events.map((callback: any) => {
-      return new Promise<void>((resolve) => {
-        callback(
-          result,
-          async (commit = true) => {
-            if (this.config.autoCommit) {
-              return resolve()
-            }
-            if (commit) {
-              const offset = (Number(message.offset) + 1).toString()
-              await this.consumer.commitOffsets([{ topic, partition, offset }])
-            }
+    const promises = callbacks.map((callback) => {
+      return new Promise<void>(async (resolve, reject) => {
+        let committed = false
 
+        const committer: ConsumerCommitCallback = async (commit = true) => {
+          committed = true
+
+          if (this.config.autoCommit) {
+            return resolve()
+          }
+
+          if (commit) {
+            const offset = (Number(message.offset) + 1).toString()
+            await this.consumer.commitOffsets([{ topic, partition, offset }])
+          }
+
+          resolve()
+        }
+
+        try {
+          await callback(result, committer, heartbeat, pause)
+        } catch (error) {
+          this.handleError(topic, error)
+          resolve()
+        }
+
+        if (!committed) {
+          if (this.config.autoCommit) {
             resolve()
-          },
-          payload
-        )
+          } else {
+            reject(new Error('Expected commit() to be called as autoCommit is false'))
+          }
+        }
       })
     })
 
@@ -96,12 +114,14 @@ export class Consumer {
     return this
   }
 
-  async on(subscription: ConsumerSubscribeTopics, callback: any): Promise<void>
-  async on(subscription: ConsumerSubscribeTopic, callback: any): Promise<void>
-  async on(subscription: ConsumerSubscribeTopic & ConsumerSubscribeTopics, callback: any) {
-    const callbackFn = this.resolveCallback(callback)
-    if (!callbackFn) {
-      throw new Error('no callback specified or cannot find your controller method')
+  async on(subscription: ConsumerSubscribeTopics, callback: ConsumerCallback): Promise<void>
+  async on(subscription: ConsumerSubscribeTopic, callback: ConsumerCallback): Promise<void>
+  async on(
+    subscription: ConsumerSubscribeTopic & ConsumerSubscribeTopics,
+    callback: ConsumerCallback
+  ) {
+    if (typeof callback !== 'function') {
+      throw new TypeError('Consumer callback is not a function')
     }
 
     let topics = []
@@ -114,7 +134,7 @@ export class Consumer {
     topics.forEach(async (item) => {
       const events = this.events[item] || []
 
-      events.push(callbackFn)
+      events.push(callback)
 
       this.events[item] = events
 
@@ -127,7 +147,7 @@ export class Consumer {
     })
   }
 
-  raiseError(topic: string, error: Error) {
+  handleError(topic: string, error: Error) {
     const handlers = this.errorHandlers[topic] || []
     handlers.forEach((handler) => {
       handler(error)
@@ -135,25 +155,8 @@ export class Consumer {
   }
 
   onError(topic: string, callback: ConsumerErrorHandler) {
-    //TODO add resolveCallback
     const handlers = this.errorHandlers[topic] || []
     handlers.push(callback)
     this.errorHandlers[topic] = handlers
-  }
-
-  resolveCallback(callback: any) {
-    if (Array.isArray(callback)) {
-      const [ControllerClass, fn] = callback
-      const controller = new ControllerClass()
-      if (typeof controller[fn] === 'function') {
-        return controller[fn].bind(controller)
-      }
-    }
-
-    if (typeof callback === 'function') {
-      return callback
-    }
-
-    return null
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type {
   ProducerConfig as KafkaProducerConfig,
   ConsumerRunConfig as KafkaConsumerRunConfig,
   Message as KafkaMessage,
+  EachMessagePayload as KafkaEachMessagePayload,
 } from 'kafkajs'
 import type { Level } from '@adonisjs/logger/types'
 import type { Consumer } from './consumer.ts'
@@ -17,6 +18,15 @@ export type ConsumerGroupConfig = KafkaConsumerConfig &
 
 export type ConsumerSubscribeTopic = { topic: string; fromBeginning?: boolean }
 export type ConsumerSubscribeTopics = { topics: string[]; fromBeginning?: boolean }
+
+export type ConsumerPayload = KafkaMessage
+export type ConsumerCommitCallback = (commit: boolean) => Promise<void>
+export type ConsumerCallback = (
+  payload: ConsumerPayload,
+  commit: ConsumerCommitCallback,
+  heartbeat: KafkaEachMessagePayload['heartbeat'],
+  pause: KafkaEachMessagePayload['pause']
+) => Promise<void>
 
 export type ConsumerErrorHandler = (error: Error) => void
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,11 @@ export type ProducerConfig = KafkaProducerConfig
 export type ConsumerGroupConfig = KafkaConsumerConfig &
   Omit<KafkaConsumerRunConfig, 'eachMessage' | 'eachBatch'>
 
+export type ConsumerSubscribeTopic = { topic: string; fromBeginning?: boolean }
+export type ConsumerSubscribeTopics = { topics: string[]; fromBeginning?: boolean }
+
+export type ConsumerErrorHandler = (error: Error) => void
+
 declare module '@adonisjs/core/types' {
   export interface ContainerBindings {
     kafka: Kafka

--- a/tests/consumer.spec.ts
+++ b/tests/consumer.spec.ts
@@ -95,7 +95,7 @@ test.group('Kafka Consumer', (group) => {
     assert.isTrue(handler3.calledWith(error2))
 
     // No error handler for topic 3
-    consumer.handleError('topic-3', error1)
+    assert.doesNotThrow(() => consumer.handleError('topic-3', error1))
     assert.equal(handler1.callCount, 1)
     assert.equal(handler2.callCount, 1)
     assert.equal(handler3.callCount, 1)

--- a/tests/consumer.spec.ts
+++ b/tests/consumer.spec.ts
@@ -35,44 +35,6 @@ test.group('Kafka Consumer', (group) => {
     assert.equal(run.callCount, 1)
   })
 
-  // technically this is a private method, just doing this as an exercise for now
-  test('resolveCallback: fn', ({ assert }) => {
-    const kafkajs = new Kafkajs({
-      brokers: ['asd'],
-    })
-
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
-    const callback = sinon.spy()
-    const resolved = consumer.resolveCallback(callback)
-    assert.equal(callback, resolved)
-  })
-
-  // technically this is a private method, just doing this as an exercise for now
-  test('resolveCallback: method', ({ assert }) => {
-    const kafkajs = new Kafkajs({
-      brokers: ['asd'],
-    })
-
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
-    class Foo {
-      callback() {}
-    }
-
-    const resolved = consumer.resolveCallback([Foo, 'callback'])
-    assert.equal(resolved.name, 'bound callback')
-  })
-
-  // technically this is a private method, just doing this as an exercise for now
-  test('resolveCallback: wrong', ({ assert }) => {
-    const kafkajs = new Kafkajs({
-      brokers: ['asd'],
-    })
-
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
-    const resolved = consumer.resolveCallback(123)
-    assert.isNull(resolved)
-  })
-
   test('errorHandler fn', ({ assert }) => {
     const kafkajs = new Kafkajs({
       brokers: ['asd'],
@@ -82,7 +44,7 @@ test.group('Kafka Consumer', (group) => {
     const handler = sinon.spy()
     consumer.onError('test', handler)
     const error = new Error('test')
-    consumer.raiseError('test', error)
+    consumer.handleError('test', error)
 
     assert.isTrue(handler.called)
     assert.equal(handler.callCount, 1)
@@ -109,7 +71,7 @@ test.group('Kafka Consumer', (group) => {
     const error2 = new Error('test2')
 
     // One error handler for topic 1
-    consumer.raiseError('topic-1', error1)
+    consumer.handleError('topic-1', error1)
 
     assert.isTrue(handler1.called)
     assert.equal(handler1.callCount, 1)
@@ -119,7 +81,7 @@ test.group('Kafka Consumer', (group) => {
 
     assert.isTrue(handler1.calledWith(error1))
 
-    consumer.raiseError('topic-2', error2)
+    consumer.handleError('topic-2', error2)
 
     // handler 1 shouldn't be called for topic-2
     assert.equal(handler1.callCount, 1)
@@ -133,7 +95,7 @@ test.group('Kafka Consumer', (group) => {
     assert.isTrue(handler3.calledWith(error2))
 
     // No error handler for topic 3
-    consumer.raiseError('topic-3', error1)
+    consumer.handleError('topic-3', error1)
     assert.equal(handler1.callCount, 1)
     assert.equal(handler2.callCount, 1)
     assert.equal(handler3.callCount, 1)
@@ -200,7 +162,7 @@ test.group('Kafka Consumer', (group) => {
   })
 
   // technically an internal method, but still
-  test('execute null message', async ({ assert }) => {
+  test('eachMessage null message', async ({ assert }) => {
     const kafkajs = new Kafkajs({
       brokers: ['asd'],
     })
@@ -229,7 +191,7 @@ test.group('Kafka Consumer', (group) => {
   })
 
   // technically an internal method, but still
-  test('execute wrong JSON', async ({ assert }) => {
+  test('eachMessage wrong JSON', async ({ assert }) => {
     const kafkajs = new Kafkajs({
       brokers: ['asd'],
     })
@@ -237,8 +199,7 @@ test.group('Kafka Consumer', (group) => {
     const consumer = new Consumer(kafkajs, { groupId: 'test' })
     const callback = sinon.stub().callsArg(1)
     consumer.events['test'] = [callback]
-    const handler = sinon.spy()
-    consumer.onError('test', handler)
+    const handleError = sinon.replace(consumer, 'handleError', sinon.fake())
 
     const message = {
       value: Buffer.from('{.123}'),
@@ -257,12 +218,14 @@ test.group('Kafka Consumer', (group) => {
     })
     assert.isFalse(callback.called)
     assert.isUndefined(result)
-    assert.isTrue(handler.called)
-    assert.isTrue(handler.args[0][0] instanceof SyntaxError)
+    assert.isTrue(handleError.called)
+
+    assert.isTrue(handleError.calledWith('test'))
+    assert.instanceOf(handleError.firstCall.args[1], SyntaxError)
   })
 
   // technically an internal method, but still
-  test('execute autocommit false', async ({ assert }) => {
+  test('eachMessage autocommit false', async ({ assert }) => {
     const kafkajs = new Kafkajs({
       brokers: ['asd'],
     })
@@ -300,17 +263,96 @@ test.group('Kafka Consumer', (group) => {
     )
   })
 
+  test('eachMessage autocommit false never commits', async ({ assert }) => {
+    const kafkajs = new Kafkajs({
+      brokers: ['asd'],
+    })
+
+    const consumer = new Consumer(kafkajs, { groupId: 'test', autoCommit: false })
+    const subscribe = sinon.replace(consumer.consumer, 'subscribe', sinon.spy())
+    const commitOffset = sinon.replace(consumer.consumer, 'commitOffsets', sinon.spy())
+    // Note: we are not calling the commit() function here:
+    const callback = sinon.stub()
+
+    consumer.on({ topic: 'test' }, callback)
+
+    const message = {
+      value: Buffer.from('123'),
+      key: null,
+      timestamp: '2024-05-03',
+      attributes: 0,
+      offset: '1',
+      headers: {},
+    }
+
+    assert.isTrue(subscribe.called)
+
+    assert.rejects(
+      async () =>
+        await consumer.eachMessage({
+          topic: 'test',
+          partition: 1,
+          message,
+          heartbeat: sinon.spy(),
+          pause: sinon.spy(),
+        }),
+      'Expected commit() to be called as autoCommit is false'
+    )
+
+    assert.isTrue(callback.called)
+    assert.isFalse(commitOffset.called)
+  })
+
+  test('eachMessage autocommit non-explicit', async ({ assert }) => {
+    const kafkajs = new Kafkajs({
+      brokers: ['asd'],
+    })
+
+    const consumer = new Consumer(kafkajs, { groupId: 'test', autoCommit: true })
+    const subscribe = sinon.replace(consumer.consumer, 'subscribe', sinon.spy())
+    const commitOffset = sinon.replace(consumer.consumer, 'commitOffsets', sinon.spy())
+    // Note: we are not calling the commit() function here:
+    const callback = sinon.stub()
+
+    consumer.on({ topic: 'test' }, callback)
+
+    const message = {
+      value: Buffer.from('123'),
+      key: null,
+      timestamp: '2024-05-03',
+      attributes: 0,
+      offset: '1',
+      headers: {},
+    }
+
+    assert.isTrue(subscribe.called)
+
+    assert.doesNotReject(
+      async () =>
+        await consumer.eachMessage({
+          topic: 'test',
+          partition: 1,
+          message,
+          heartbeat: sinon.spy(),
+          pause: sinon.spy(),
+        })
+    )
+
+    assert.isTrue(callback.called)
+    assert.isFalse(commitOffset.called)
+  })
+
   // technically an internal method, but still
-  test('execute with heartbeat & pause', async ({ assert }) => {
+  test('eachMessage with heartbeat & pause', async ({ assert }) => {
     const kafkajs = new Kafkajs({
       brokers: ['asd'],
     })
 
     const consumer = new Consumer(kafkajs, { groupId: 'test' })
     sinon.replace(consumer.consumer, 'commitOffsets', sinon.spy())
-    const callback = sinon.stub().callsFake(async function (_result, commit, payload) {
-      await payload.heartbeat()
-      await payload.pause()
+    const callback = sinon.stub().callsFake(async function (_result, commit, heartbeat, pause) {
+      await heartbeat()
+      await pause()
       await commit(true)
     })
     consumer.events['test'] = [callback]
@@ -339,6 +381,7 @@ test.group('Kafka Consumer', (group) => {
     const wrongCallback = 123
     assert.rejects(
       async () =>
+        // @ts-expect-error
         await consumer.on(
           {
             topic: 'test',
@@ -515,5 +558,48 @@ test.group('Kafka Consumer', (group) => {
         fromBeginning: true,
       })
     )
+  })
+
+  test('on callback throws', async ({ assert }) => {
+    const kafkajs = new Kafkajs({
+      brokers: ['asd'],
+    })
+
+    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const subscribe = sinon.replace(consumer.consumer, 'subscribe', sinon.spy())
+    const handleError = sinon.replace(consumer, 'handleError', sinon.fake())
+    const callback = sinon.stub().throws()
+
+    await consumer.on(
+      {
+        topics: ['test'],
+        fromBeginning: true,
+      },
+      callback
+    )
+
+    assert.isTrue(subscribe.called)
+
+    const message = {
+      value: Buffer.from('123'),
+      key: null,
+      timestamp: '2024-05-03',
+      attributes: 0,
+      offset: '1',
+      headers: {},
+    }
+
+    assert.doesNotReject(async () => {
+      await consumer.eachMessage({
+        topic: 'test',
+        partition: 1,
+        message,
+        heartbeat: sinon.spy(),
+        pause: sinon.spy(),
+      })
+    })
+
+    assert.isTrue(callback.called)
+    assert.isTrue(handleError.called)
   })
 })

--- a/tests/consumer.spec.ts
+++ b/tests/consumer.spec.ts
@@ -80,7 +80,7 @@ test.group('Kafka Consumer', (group) => {
 
     const consumer = new Consumer(kafkajs, { groupId: 'test' })
     const handler = sinon.spy()
-    consumer.registerErrorHandler('test', handler)
+    consumer.onError('test', handler)
     const error = new Error('test')
     consumer.raiseError('test', error)
 
@@ -97,13 +97,13 @@ test.group('Kafka Consumer', (group) => {
     const consumer = new Consumer(kafkajs, { groupId: 'test' })
 
     const handler1 = sinon.spy()
-    consumer.registerErrorHandler('topic-1', handler1)
+    consumer.onError('topic-1', handler1)
 
     const handler2 = sinon.spy()
-    consumer.registerErrorHandler('topic-2', handler2)
+    consumer.onError('topic-2', handler2)
 
     const handler3 = sinon.spy()
-    consumer.registerErrorHandler('topic-2', handler3)
+    consumer.onError('topic-2', handler3)
 
     const error1 = new Error('test1')
     const error2 = new Error('test2')
@@ -238,7 +238,7 @@ test.group('Kafka Consumer', (group) => {
     const callback = sinon.stub().callsArg(1)
     consumer.events['test'] = [callback]
     const handler = sinon.spy()
-    consumer.registerErrorHandler('test', handler)
+    consumer.onError('test', handler)
 
     const message = {
       value: Buffer.from('{.123}'),


### PR DESCRIPTION
This removes the `resolveCallback` logic, in favor of flat callbacks for now (pending the Consumer class implementation, which supersedes the `.on(...)` interface logic), and fixes all the callbacks to be correctly typed.

Additionally, I noticed that there was a potential error path where if a user forgot to call `commit` and `autoCommit` was false, then we'd get stuck — that now throws an error so that the application will crash. (expectation is you'll catch this in development/tests)

"Support" for regex topics is also explicitly dropped via the type signature of `on()`, whilst multiple topics support is now explicitly supported.

I've also split out the `heartbeat` and `pause` methods to explicit arguments of a topic subscription callback, as well as handling cases where an async callback may throw (this now triggers the error handler)