### PR TITLE
Rename Consumer to ConsumerGroup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,6 @@
 
 export { configure } from './configure.ts'
 export { Kafka } from './src/index.ts'
-export { Consumer } from './src/consumer.ts'
+export { ConsumerGroup } from './src/consumer_group.ts'
 export { Producer } from './src/producer.ts'
 export { defineConfig } from './src/define_config.ts'

--- a/providers/kafka_provider.ts
+++ b/providers/kafka_provider.ts
@@ -20,24 +20,18 @@ export default class KafkaProvider implements ContainerProviderContract {
 
   async boot() {
     const kafka = await this.app.container.make('kafka')
-    await kafka.start()
+    await kafka.boot()
   }
 
   // Has to be ready to make use of preloads:
   async ready() {
     const kafka = await this.app.container.make('kafka')
-
-    for (const producer in kafka.producers) {
-      await kafka.producers[producer].start()
-    }
-
-    for (const consumer of kafka.consumers) {
-      await consumer.start()
-    }
+    await kafka.startProducers()
+    await kafka.startConsumerGroups()
   }
 
   async shutdown() {
     const kafka = await this.app.container.make('kafka')
-    await kafka.disconnect()
+    await kafka.stop()
   }
 }

--- a/src/consumer_group.ts
+++ b/src/consumer_group.ts
@@ -10,7 +10,7 @@ import type {
   ConsumerCommitCallback,
 } from './types.ts'
 
-export class Consumer {
+export class ConsumerGroup {
   config: ConsumerGroupConfig
   topics: string[]
   events: Record<string, ConsumerCallback[]>

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ import type {
 import type tls from 'node:tls'
 
 import type { Level } from '@adonisjs/logger/types'
-import type { Consumer } from './consumer.ts'
+import type { ConsumerGroup } from './consumer_group.ts'
 import type { Producer } from './producer.ts'
 
 import { Kafka } from './index.ts'
@@ -54,10 +54,13 @@ declare module '@adonisjs/core/types' {
   }
 
   export interface KafkaContract {
-    start: (...args: any[]) => void
-    disconnect: () => void
+    boot(...args: any[]): void
+    startConsumerGroups(): Promise<void>
+    startProducers(): Promise<void>
+    stop(): Promise<void>
+
     createProducer(name: string, config?: ProducerConfig): Producer
-    createConsumer(config: ConsumerGroupConfig): Consumer
+    createConsumerGroup(config: ConsumerGroupConfig): ConsumerGroup
   }
 }
 

--- a/tests/consumer_group.spec.ts
+++ b/tests/consumer_group.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@japa/runner'
 import * as sinon from 'sinon'
 
-import { Consumer } from '../src/consumer.ts'
+import { ConsumerGroup } from '../src/consumer_group.ts'
 import { Kafka as Kafkajs } from 'kafkajs'
 process.env['KAFKAJS_NO_PARTITIONER_WARNING'] = '1'
 
@@ -15,7 +15,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
     const consumer = sinon.spy(kafkajs, 'consumer')
-    new Consumer(kafkajs, { groupId: 'test' })
+    new ConsumerGroup(kafkajs, { groupId: 'test' })
     assert.isTrue(consumer.called)
   })
 
@@ -24,7 +24,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     const connect = sinon.replace(consumer.consumer, 'connect', sinon.fake())
     const run = sinon.replace(consumer.consumer, 'run', sinon.fake())
     await consumer.start()
@@ -40,7 +40,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     const handler = sinon.spy()
     consumer.onError('test', handler)
     const error = new Error('test')
@@ -56,7 +56,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
 
     const handler1 = sinon.spy()
     consumer.onError('topic-1', handler1)
@@ -106,7 +106,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test', autoCommit: false })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test', autoCommit: false })
     const eachMessage = sinon.spy(consumer, 'eachMessage')
 
     const message = {
@@ -138,7 +138,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test', autoCommit: true })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test', autoCommit: true })
     sinon.replace(consumer.consumer, 'commitOffsets', sinon.spy())
     const callback = sinon.stub().callsArg(1)
     consumer.events['test'] = [callback]
@@ -167,7 +167,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     const callback = sinon.stub().callsArg(1)
     consumer.events['test'] = [callback]
 
@@ -196,7 +196,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     const callback = sinon.stub().callsArg(1)
     consumer.events['test'] = [callback]
     const handleError = sinon.replace(consumer, 'handleError', sinon.fake())
@@ -230,7 +230,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test', autoCommit: false })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test', autoCommit: false })
     const commitOffset = sinon.replace(consumer.consumer, 'commitOffsets', sinon.spy())
     const callback = sinon.stub().callsArgWith(1, true)
     consumer.events['test'] = [callback]
@@ -268,7 +268,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test', autoCommit: false })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test', autoCommit: false })
     const subscribe = sinon.replace(consumer.consumer, 'subscribe', sinon.spy())
     const commitOffset = sinon.replace(consumer.consumer, 'commitOffsets', sinon.spy())
     // Note: we are not calling the commit() function here:
@@ -308,7 +308,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test', autoCommit: true })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test', autoCommit: true })
     const subscribe = sinon.replace(consumer.consumer, 'subscribe', sinon.spy())
     const commitOffset = sinon.replace(consumer.consumer, 'commitOffsets', sinon.spy())
     // Note: we are not calling the commit() function here:
@@ -348,7 +348,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     sinon.replace(consumer.consumer, 'commitOffsets', sinon.spy())
     const callback = sinon.stub().callsFake(async function (_result, commit, heartbeat, pause) {
       await heartbeat()
@@ -377,7 +377,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     const wrongCallback = 123
     assert.rejects(
       async () =>
@@ -397,7 +397,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     const subscribe = sinon.replace(consumer.consumer, 'subscribe', sinon.spy())
     const callback = sinon.spy()
     assert.doesNotReject(
@@ -426,7 +426,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     const subscribe = sinon.replace(consumer.consumer, 'subscribe', sinon.spy())
     const callback = sinon.spy()
     assert.doesNotReject(
@@ -454,7 +454,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     const subscribe = sinon.replace(consumer.consumer, 'subscribe', sinon.spy())
     const callback = sinon.spy()
     assert.doesNotReject(
@@ -481,7 +481,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     const subscribe = sinon.replace(consumer.consumer, 'subscribe', sinon.spy())
     const callback = sinon.spy()
     assert.doesNotReject(
@@ -509,7 +509,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     const subscribe = sinon.replace(consumer.consumer, 'subscribe', sinon.spy())
     const callback = sinon.spy()
     assert.doesNotReject(
@@ -537,7 +537,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     const subscribe = sinon.replace(consumer.consumer, 'subscribe', sinon.spy())
     const callback = sinon.spy()
     assert.doesNotReject(
@@ -565,7 +565,7 @@ test.group('Kafka Consumer', (group) => {
       brokers: ['asd'],
     })
 
-    const consumer = new Consumer(kafkajs, { groupId: 'test' })
+    const consumer = new ConsumerGroup(kafkajs, { groupId: 'test' })
     const subscribe = sinon.replace(consumer.consumer, 'subscribe', sinon.spy())
     const handleError = sinon.replace(consumer, 'handleError', sinon.fake())
     const callback = sinon.stub().throws()

--- a/tests/provider.spec.ts
+++ b/tests/provider.spec.ts
@@ -4,7 +4,7 @@ import { IgnitorFactory } from '@adonisjs/core/factories'
 import { Kafka } from '../src/index.ts'
 import sinon from 'sinon'
 import { Producer } from '../src/producer.ts'
-import { Consumer } from '../src/consumer.ts'
+import { ConsumerGroup } from '../src/consumer_group.ts'
 
 const BASE_URL = new URL('./tmp/', import.meta.url)
 
@@ -46,19 +46,19 @@ test.group('Kafka Provider', () => {
     const producer = kafkaService.createProducer('test')
     assert.instanceOf(producer, Producer)
 
-    const consumer = kafkaService.createConsumer({
+    const consumerGroup = kafkaService.createConsumerGroup({
       groupId: 'test',
       autoCommit: false,
     })
-    assert.instanceOf(consumer, Consumer)
+    assert.instanceOf(consumerGroup, ConsumerGroup)
 
-    const consumerStart = sinon.spy(consumer, 'start')
+    const consumerStart = sinon.spy(consumerGroup, 'start')
     const producerStart = sinon.spy(producer, 'start')
 
     const producerConnect = sinon.replace(producer.producer, 'connect', sinon.fake())
 
-    const consumerConnect = sinon.replace(consumer.consumer, 'connect', sinon.fake())
-    const consumerRun = sinon.replace(consumer.consumer, 'run', sinon.fake())
+    const consumerConnect = sinon.replace(consumerGroup.consumer, 'connect', sinon.fake())
+    const consumerRun = sinon.replace(consumerGroup.consumer, 'run', sinon.fake())
 
     let started = false
     await app.start(async () => {
@@ -77,15 +77,15 @@ test.group('Kafka Provider', () => {
     assert.equal(producerStart.callCount, 1)
     assert.equal(consumerStart.callCount, 1)
 
-    const consumerStop = sinon.spy(consumer, 'stop')
-    const consumerDisconnect = sinon.replace(consumer.consumer, 'disconnect', sinon.fake())
+    const consumerStop = sinon.spy(consumerGroup, 'stop')
+    const consumerDisconnect = sinon.replace(consumerGroup.consumer, 'disconnect', sinon.fake())
     const producerStop = sinon.spy(producer, 'stop')
     const producerDisconnect = sinon.replace(producer.producer, 'disconnect', sinon.fake())
 
-    const disconnect = sinon.spy(kafka, 'disconnect')
+    const stop = sinon.spy(kafka, 'stop')
 
     await app.terminate()
-    assert.isTrue(disconnect.called, 'kafka.disconnect called')
+    assert.isTrue(stop.called, 'kafka.stop called')
     assert.isTrue(consumerStop.called, 'consumer.stop called')
     assert.isTrue(producerStop.called, 'producer.stop called')
 
@@ -123,20 +123,20 @@ test.group('Kafka Provider', () => {
     assert.instanceOf(kafka, Kafka)
 
     const producer = kafka.createProducer('test')
-    const consumer = kafka.createConsumer({
+    const consumerGroup = kafka.createConsumerGroup({
       groupId: 'test',
       autoCommit: false,
     })
 
-    const consumerStop = sinon.spy(consumer, 'stop')
-    const consumerDisconnect = sinon.replace(consumer.consumer, 'disconnect', sinon.fake())
+    const consumerStop = sinon.spy(consumerGroup, 'stop')
+    const consumerDisconnect = sinon.replace(consumerGroup.consumer, 'disconnect', sinon.fake())
     const producerStop = sinon.spy(producer, 'stop')
     const producerDisconnect = sinon.replace(producer.producer, 'disconnect', sinon.fake())
 
-    const disconnect = sinon.spy(kafka, 'disconnect')
+    const stop = sinon.spy(kafka, 'stop')
 
     await app.terminate()
-    assert.isTrue(disconnect.called)
+    assert.isTrue(stop.called)
     assert.isTrue(consumerStop.called)
     assert.isTrue(producerStop.called)
 


### PR DESCRIPTION
This also changes the internal APIs a little bit to be clearer:
- `kafka.start` becomes `kafka.boot`, since it happens on boot
- introduces `startConsumerGroups` and `startProducers` methods, instead of exposing the internal data structure to the kafka provider.
- `kafka.disconnect` becomes `kafka.stop` — _we could introduce `stopConsumerGroups` and `stopProducers` as well, instead of just a singular `kafka.stop`

This PR needs to land before I can go back to work on #9 