### PR TITLE
Improve package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,17 @@
 {
   "name": "@neighbourhoodie/adonis-kafka",
-  "description": "",
+  "description": "Adonis v6 adapter for Kafka.js",
+  "homepage": "https://github.com/neighbourhoodie/adonis-kafka-v6"
+  "bugs": {
+    "url": "https://github.com/neighbourhoodie/adonis-kafka-v6/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neighbourhoodie/adonis-kafka-v6.git"
+  },
+  "keywords": ["adonis", "kafka"],
+  "author": "The Neighbourhoodie Software GmbH & contributors",
+  "license": "MIT",
   "version": "0.3.2",
   "main": "build/index.js",
   "engines": {
@@ -33,9 +44,6 @@
     "version": "npm run build",
     "prepublishOnly": "npm run build"
   },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
   "devDependencies": {
     "@adonisjs/assembler": "^7.0.0",
     "@adonisjs/core": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@neighbourhoodie/adonis-kafka",
   "description": "Adonis v6 adapter for Kafka.js",
-  "homepage": "https://github.com/neighbourhoodie/adonis-kafka-v6"
+  "homepage": "https://github.com/neighbourhoodie/adonis-kafka-v6",
   "bugs": {
     "url": "https://github.com/neighbourhoodie/adonis-kafka-v6/issues"
   },


### PR DESCRIPTION
I noticed dependabot wasn't linking in release notes for each version, now it should (I suspect it didn't know about the repository because it was missing from the package.json)

This should be fixed from the next version